### PR TITLE
Handle switchCases without break or return

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -897,7 +897,7 @@
             return bName;
         },
 
-        branchIncrementExprAst: function (varName, branchIndex, down) {
+        branchIncrementExprAst: function (varName, branchIndex, down, node, nodeCase) {
             var ret = astgen.postIncrement(
                 astgen.subscript(
                     astgen.subscript(
@@ -908,6 +908,26 @@
                 ),
                 down
             );
+            if (nodeCase && nodeCase.test && node && node.discriminant) {
+              var ifStmt = {
+                "type": "IfStatement",
+                "test": {
+                  "type" : "BinaryExpression",
+                  "left" : node.discriminant,
+                  "operator" : "==",
+                  "right" : nodeCase.test
+                },
+                "consequent" : {
+                  "type" : "BlockStatement",
+                  "body" : [{
+                    "type" : "ExpressionStatement",
+                    "expression" : ret
+                  }]
+                },
+                "alternate": null
+              };
+              return ifStmt;
+            }
             return ret;
         },
 
@@ -956,7 +976,7 @@
             bName = this.branchName('switch', walker.startLineForNode(node), this.locationsForNodes(cases));
             for (i = 0; i < cases.length; i += 1) {
                 cases[i].branchLocation = this.branchLocationFor(bName, i);
-                cases[i].consequent.unshift(astgen.statement(this.branchIncrementExprAst(bName, i)));
+                cases[i].consequent.unshift(astgen.statement(this.branchIncrementExprAst(bName, i, null, cases[i], node)));
             }
         },
 


### PR DESCRIPTION
Add an `if` statement on the **branch autoincrement** to test :  
-  if we are in this `case` because of the `case` value,  
-  or because there was no `break` or `return` before.
#### Example :

before :   

```
switch (foo) {
  case 'bar':
    alert(foo);
  case 'baz':
    alert('Hello ' + foo);
    break;
}  
```

after :   

```
switch (foo) {
  case 'bar':
    if (foo == 'bar') __cov_ezf654zfe468['b'][0][1] ++;
    alert(foo);
  case 'baz':
    if (foo == 'baz') __cov_ezf654zfe468['b'][0][2] ++;
    alert('Hello ' + foo);
    break;
}
```
